### PR TITLE
Do lazy/forced unmount when player exits

### DIFF
--- a/scripts/btplay
+++ b/scripts/btplay
@@ -71,7 +71,7 @@ if ret == 0:
 	except:
 		ret = 2
 	finally:
-		subprocess.call(("fusermount", "-u", mountpoint, ))
+		subprocess.call(("fusermount", "-z", "-u", mountpoint, ))
 
 shutil.rmtree(mountpoint)
 


### PR DESCRIPTION
This can still not guarantee that the btfs process exits or the torrent is
stopped, only that the process will eventually exit when all open files are
closed.